### PR TITLE
🐛 Rootfinding Change `s` -> `t` in Comment

### DIFF
--- a/book/Contents/rootfinding.ipynb
+++ b/book/Contents/rootfinding.ipynb
@@ -147,7 +147,7 @@
     "ax = fig.add_axes([0,0,1,1])\n",
     "n = 501\n",
     "t = np.linspace(-0.2,0.2,n)\n",
-    "y = 1/4+3*t+t*t;  # Newton would have written s^2 as s*s, too\n",
+    "y = 1/4+3*t+t*t;  # Newton would have written t^2 as t*t, too\n",
     "\n",
     "plt.plot(t,y,'b')   # equation in blue again\n",
     "ax.grid(True, which='both')\n",


### PR DESCRIPTION
###What
Change the variable `s` -> `t` in an inline comment about Newton.

###Why
The varibale actually used in the code is a `t`, but in a previous example it was `s`. I suspect this was a copy/paste issue. 